### PR TITLE
Turn off all cron

### DIFF
--- a/scripts/scrapers-us-municipal-crontask
+++ b/scripts/scrapers-us-municipal-crontask
@@ -1,16 +1,16 @@
 # /etc/cron.d/scrapers-us-municipal-crontask
 # New York City
-0 5 * * * datamade /usr/bin/flock /tmp/nycscrape.lock -c 'cd /home/datamade/scrapers-us-municipal && /home/datamade/.virtualenvs/opencivicdata/bin/pupa update nyc >> /tmp/nyc.log 2>&1'
-0,15,30,45 * * * * datamade /usr/bin/flock -n /tmp/nycevents.lock -c 'cd /home/datamade/scrapers-us-municipal && /home/datamade/.virtualenvs/opencivicdata/bin/pupa update --datadir=/cache/events/_data/ nyc events window=0.05 >> /tmp/nyc.log 2>&1'
-10,25,40,55 * * * * datamade /usr/bin/flock -n /tmp/nycbills.lock -c 'cd /home/datamade/scrapers-us-municipal && /home/datamade/.virtualenvs/opencivicdata/bin/pupa update --datadir=/cache/bills/_data/ nyc bills window=0.05 >> /tmp/nyc.log 2>&1'
+# 0 5 * * * datamade /usr/bin/flock /tmp/nycscrape.lock -c 'cd /home/datamade/scrapers-us-municipal && /home/datamade/.virtualenvs/opencivicdata/bin/pupa update nyc >> /tmp/nyc.log 2>&1'
+# 0,15,30,45 * * * * datamade /usr/bin/flock -n /tmp/nycevents.lock -c 'cd /home/datamade/scrapers-us-municipal && /home/datamade/.virtualenvs/opencivicdata/bin/pupa update --datadir=/cache/events/_data/ nyc events window=0.05 >> /tmp/nyc.log 2>&1'
+# 10,25,40,55 * * * * datamade /usr/bin/flock -n /tmp/nycbills.lock -c 'cd /home/datamade/scrapers-us-municipal && /home/datamade/.virtualenvs/opencivicdata/bin/pupa update --datadir=/cache/bills/_data/ nyc bills window=0.05 >> /tmp/nyc.log 2>&1'
 
 
 # Chicago
-0 2 * * * datamade /usr/bin/flock /tmp/chicagobills.lock /usr/bin/flock /tmp/chicagoevents.lock -c 'cd /home/datamade/scrapers-us-municipal && /home/datamade/.virtualenvs/opencivicdata/bin/pupa update chicago >> /tmp/chicago.log 2>&1'
-10,25,40,55 * * * * datamade /usr/bin/flock /tmp/chicagoevents.lock -c 'cd /home/datamade/scrapers-us-municipal && /home/datamade/.virtualenvs/opencivicdata/bin/pupa update --datadir=/cache/events/_data/ chicago events window=0.05 >> /tmp/chicago.log 2>&1'
-5,20,35,50 * * * * datamade /usr/bin/flock -n /tmp/chicagobills.lock -c 'cd /home/datamade/scrapers-us-municipal && /home/datamade/.virtualenvs/opencivicdata/bin/pupa update --datadir=/cache/bills/_data/ chicago bills window=0.05 >> /tmp/chicago.log 2>&1'
+# 0 2 * * * datamade /usr/bin/flock /tmp/chicagobills.lock /usr/bin/flock /tmp/chicagoevents.lock -c 'cd /home/datamade/scrapers-us-municipal && /home/datamade/.virtualenvs/opencivicdata/bin/pupa update chicago >> /tmp/chicago.log 2>&1'
+# 10,25,40,55 * * * * datamade /usr/bin/flock /tmp/chicagoevents.lock -c 'cd /home/datamade/scrapers-us-municipal && /home/datamade/.virtualenvs/opencivicdata/bin/pupa update --datadir=/cache/events/_data/ chicago events window=0.05 >> /tmp/chicago.log 2>&1'
+# 5,20,35,50 * * * * datamade /usr/bin/flock -n /tmp/chicagobills.lock -c 'cd /home/datamade/scrapers-us-municipal && /home/datamade/.virtualenvs/opencivicdata/bin/pupa update --datadir=/cache/bills/_data/ chicago bills window=0.05 >> /tmp/chicago.log 2>&1'
 
 # Los Angeles Metro
-5 0 * * * datamade /usr/bin/flock /tmp/metrobills.lock /usr/bin/flock /tmp/metroevents.lock -c 'cd /home/datamade/scrapers-us-municipal && /home/datamade/.virtualenvs/opencivicdata/bin/pupa update lametro >> /tmp/lametro.log 2>&1'
-0,15,30,45 * * * * datamade /usr/bin/flock -n /tmp/metroevents.lock -c 'cd /home/datamade/scrapers-us-municipal && /home/datamade/.virtualenvs/opencivicdata/bin/pupa update --datadir=/cache/events/_data/ lametro events window=0.05 >> /tmp/lametro.log 2>&1'
-5,20,35,50 * * * * datamade /usr/bin/flock -n /tmp/metrobills.lock -c 'cd /home/datamade/scrapers-us-municipal && /home/datamade/.virtualenvs/opencivicdata/bin/pupa update --datadir=/cache/bills/_data/ lametro bills window=0.05 >> /tmp/lametro.log 2>&1'
+# 5 0 * * * datamade /usr/bin/flock /tmp/metrobills.lock /usr/bin/flock /tmp/metroevents.lock -c 'cd /home/datamade/scrapers-us-municipal && /home/datamade/.virtualenvs/opencivicdata/bin/pupa update lametro >> /tmp/lametro.log 2>&1'
+# 0,15,30,45 * * * * datamade /usr/bin/flock -n /tmp/metroevents.lock -c 'cd /home/datamade/scrapers-us-municipal && /home/datamade/.virtualenvs/opencivicdata/bin/pupa update --datadir=/cache/events/_data/ lametro events window=0.05 >> /tmp/lametro.log 2>&1'
+# 5,20,35,50 * * * * datamade /usr/bin/flock -n /tmp/metrobills.lock -c 'cd /home/datamade/scrapers-us-municipal && /home/datamade/.virtualenvs/opencivicdata/bin/pupa update --datadir=/cache/bills/_data/ lametro bills window=0.05 >> /tmp/lametro.log 2>&1'


### PR DESCRIPTION
This PR turns off all cron tasks in preparation for running migrations against the ocd api database. Relates to https://github.com/datamade/scrapers-us-municipal/issues/12