### PR TITLE
Turn of cron while deleting memberships from Metro

### DIFF
--- a/scripts/scrapers-us-municipal-crontask
+++ b/scripts/scrapers-us-municipal-crontask
@@ -11,6 +11,6 @@
 5,20,35,50 * * * * datamade /usr/bin/flock -n /tmp/chicagobills.lock -c 'cd /home/datamade/scrapers-us-municipal && /home/datamade/.virtualenvs/opencivicdata/bin/pupa update --datadir=/cache/bills/_data/ chicago bills window=0.05 >> /tmp/chicago.log 2>&1'
 
 # Los Angeles Metro
-5 0 * * * datamade /usr/bin/flock /tmp/metrobills.lock /usr/bin/flock /tmp/metroevents.lock -c 'cd /home/datamade/scrapers-us-municipal && /home/datamade/.virtualenvs/opencivicdata/bin/pupa update lametro >> /tmp/lametro.log 2>&1'
-0,15,30,45 * * * * datamade /usr/bin/flock -n /tmp/metroevents.lock -c 'cd /home/datamade/scrapers-us-municipal && /home/datamade/.virtualenvs/opencivicdata/bin/pupa update --datadir=/cache/events/_data/ lametro events window=0.05 >> /tmp/lametro.log 2>&1'
-5,20,35,50 * * * * datamade /usr/bin/flock -n /tmp/metrobills.lock -c 'cd /home/datamade/scrapers-us-municipal && /home/datamade/.virtualenvs/opencivicdata/bin/pupa update --datadir=/cache/bills/_data/ lametro bills window=0.05 >> /tmp/lametro.log 2>&1'
+# 5 0 * * * datamade /usr/bin/flock /tmp/metrobills.lock /usr/bin/flock /tmp/metroevents.lock -c 'cd /home/datamade/scrapers-us-municipal && /home/datamade/.virtualenvs/opencivicdata/bin/pupa update lametro >> /tmp/lametro.log 2>&1'
+# 0,15,30,45 * * * * datamade /usr/bin/flock -n /tmp/metroevents.lock -c 'cd /home/datamade/scrapers-us-municipal && /home/datamade/.virtualenvs/opencivicdata/bin/pupa update --datadir=/cache/events/_data/ lametro events window=0.05 >> /tmp/lametro.log 2>&1'
+# 5,20,35,50 * * * * datamade /usr/bin/flock -n /tmp/metrobills.lock -c 'cd /home/datamade/scrapers-us-municipal && /home/datamade/.virtualenvs/opencivicdata/bin/pupa update --datadir=/cache/bills/_data/ lametro bills window=0.05 >> /tmp/lametro.log 2>&1'


### PR DESCRIPTION
This PR turns off the scraper cron while performing operations on the OCD API database (per https://github.com/datamade/la-metro-councilmatic/issues/314).