### PR TITLE
Slightly more aggressive windowed scrapes for Metro Friday night

### DIFF
--- a/scripts/scrapers-us-municipal-crontask
+++ b/scripts/scrapers-us-municipal-crontask
@@ -34,10 +34,10 @@ PUPADIR=/home/datamade/.virtualenvs/opencivicdata/bin/pupa
 5 0-5 * * 6 datamade /usr/bin/flock -n /tmp/metrobills.lock -c 'cd $APPDIR && $PUPADIR update --datadir=/cache/bills/_data/ lametro bills window=0 --rpm=0 >> /tmp/lametro.log 2>&1'
 
 # Windowed scrapes
-30,45 21-23 * * 5 datamade /usr/bin/flock -n /tmp/metroevents.lock -c 'cd $APPDIR && $PUPADIR update --datadir=/cache/events/_data/ lametro events window=0.05 >> /tmp/lametro.log 2>&1'
-35,50 21-23 * * 5 datamade /usr/bin/flock -n /tmp/metrobills.lock -c 'cd $APPDIR && $PUPADIR update --datadir=/cache/bills/_data/ lametro bills window=0.05 >> /tmp/lametro.log 2>&1'
-30,45 0-5 * * 6 datamade /usr/bin/flock -n /tmp/metroevents.lock -c 'cd $APPDIR && $PUPADIR update --datadir=/cache/events/_data/ lametro events window=0.05 >> /tmp/lametro.log 2>&1'
-35,50 0-5 * * 6 datamade /usr/bin/flock -n /tmp/metrobills.lock -c 'cd $APPDIR && $PUPADIR update --datadir=/cache/bills/_data/ lametro bills window=0.05 >> /tmp/lametro.log 2>&1'
+30,45 21-23 * * 5 datamade /usr/bin/flock -n /tmp/metroevents.lock -c 'cd $APPDIR && $PUPADIR update --datadir=/cache/events/_data/ lametro events window=1 >> /tmp/lametro.log 2>&1'
+35,50 21-23 * * 5 datamade /usr/bin/flock -n /tmp/metrobills.lock -c 'cd $APPDIR && $PUPADIR update --datadir=/cache/bills/_data/ lametro bills window=1 >> /tmp/lametro.log 2>&1'
+30,45 0-5 * * 6 datamade /usr/bin/flock -n /tmp/metroevents.lock -c 'cd $APPDIR && $PUPADIR update --datadir=/cache/events/_data/ lametro events window=1 >> /tmp/lametro.log 2>&1'
+35,50 0-5 * * 6 datamade /usr/bin/flock -n /tmp/metrobills.lock -c 'cd $APPDIR && $PUPADIR update --datadir=/cache/bills/_data/ lametro bills window=1 >> /tmp/lametro.log 2>&1'
 
 # Metro: Saturday, 6:00 am UTC 11:50 pm UTC
 # Windowed scrapes


### PR DESCRIPTION
@hancush I briefly mentioned this at our meeting today. In short, we recently modified the scraper to run: full scrapes, only once per hour, and windowed scrapes, three times per hour, but with a 15 minute window. 

https://github.com/datamade/la-metro-councilmatic/issues/419

This window strikes me as too small, given that Legistar raises more 104s on Friday, when we're asking a lot of the site. I think  `window=1` will insure that we do not miss data, if a couple scrapes fail consecutively. Thus, less manual intervention on Fridays. 