### PR TITLE
Updating how to merge from upstream repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Then pull from origin of this fork.
 git pull origin master
 ```
 
-Next, rebase your changes onto upstream master.
+Commit your local changes, if any. Next, rebase your changes onto upstream master.
 
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -15,14 +15,19 @@ Changes should only be made to this fork if they are related to deployment, conf
 
 As such, we want changes in this repo to all be rebased off `opencivicdata/scrapers-us-municipal`.
 
-To achieve this, first pull from origin of the fork.
+First, set up your upstream branch.
+
+```bash
+git remote add upstream https://github.com/opencivicdata/scrapers-us-municipal.git
+```
+
+Then pull from origin of this fork.
 
 ```bash
 git pull origin master
 ```
 
-Then, make your changes and commit them locally. Next, rebase your changes onto
-upstream master.
+Next, rebase your changes onto upstream master.
 
 
 ```bash


### PR DESCRIPTION
Adding some more context on how to add the upstream, just following the directions in the repo lead me to an error! (`fatal: 'upstream' does not appear to be a git repository`) It's good to be as clear as possible.

I also removed the line about committing local changes, since we want all scraper changes to be made upstream.

