### PR TITLE
Update cron to scrape into Metro upgrade DB

### DIFF
--- a/scripts/lametro/fast-full-bill-scrape.sh
+++ b/scripts/lametro/fast-full-bill-scrape.sh
@@ -1,6 +1,9 @@
 #/bin/sh
+set -e
 
-(cd $APPDIR && \
-    $PUPADIR update --datadir=/cache/bills/_data/ lametro --scrape bills --window=0 --rpm=0 && \
-    $PUPADIR update --datadir=/cache/bills/_data/ lametro --import && \
-    SHARED_DB=True DATABASE_URL=postgis://datamade@lametro-upgrade.datamade.us/lametro_staging pupa --datadir=/cache/bills/_data/ update lametro --import)
+exec 2>&1
+
+cd $APPDIR
+$PUPADIR update --datadir=/cache/bills/_data/ lametro --scrape bills --window=0 --rpm=0
+$PUPADIR update --datadir=/cache/bills/_data/ lametro --import
+SHARED_DB=True DATABASE_URL=postgis://datamade@lametro-upgrade.datamade.us/lametro_staging pupa --datadir=/cache/bills/_data/ update lametro --import

--- a/scripts/lametro/fast-full-bill-scrape.sh
+++ b/scripts/lametro/fast-full-bill-scrape.sh
@@ -1,0 +1,6 @@
+#/bin/sh
+
+(cd $APPDIR && \
+    $PUPADIR update --datadir=/cache/bills/_data/ lametro --scrape bills --window=0 --rpm=0 && \
+    $PUPADIR update --datadir=/cache/bills/_data/ lametro --import && \
+    SHARED_DB=True DATABASE_URL=postgis://datamade@lametro-upgrade.datamade.us/lametro_staging pupa --datadir=/cache/bills/_data/ update lametro --import)

--- a/scripts/lametro/fast-full-event-scrape.sh
+++ b/scripts/lametro/fast-full-event-scrape.sh
@@ -1,0 +1,6 @@
+#/bin/sh
+
+(cd $APPDIR && \
+    $PUPADIR update --datadir=/cache/events/_data/ lametro --scrape events --rpm=0 && \
+    $PUPADIR update --datadir=/cache/events/_data/ lametro --import && \
+    SHARED_DB=True DATABASE_URL=postgis://datamade@lametro-upgrade.datamade.us/lametro_staging pupa update --datadir=/cache/events/_data/ lametro --import)

--- a/scripts/lametro/fast-full-event-scrape.sh
+++ b/scripts/lametro/fast-full-event-scrape.sh
@@ -1,6 +1,9 @@
 #/bin/sh
+set -e
 
-(cd $APPDIR && \
-    $PUPADIR update --datadir=/cache/events/_data/ lametro --scrape events --rpm=0 && \
-    $PUPADIR update --datadir=/cache/events/_data/ lametro --import && \
-    SHARED_DB=True DATABASE_URL=postgis://datamade@lametro-upgrade.datamade.us/lametro_staging pupa update --datadir=/cache/events/_data/ lametro --import)
+exec 2>&1
+
+cd $APPDIR
+$PUPADIR update --datadir=/cache/events/_data/ lametro --scrape events --rpm=0
+$PUPADIR update --datadir=/cache/events/_data/ lametro --import
+SHARED_DB=True DATABASE_URL=postgis://datamade@lametro-upgrade.datamade.us/lametro_staging pupa update --datadir=/cache/events/_data/ lametro --import

--- a/scripts/lametro/full-scrape.sh
+++ b/scripts/lametro/full-scrape.sh
@@ -1,0 +1,9 @@
+#/bin/sh
+
+(cd $APPDIR && \
+    $PUPADIR update lametro --scrape && \
+    $PUPADIR update lametro --import && \
+    SHARED_DB=True DATABASE_URL=postgis://datamade@lametro-upgrade.datamade.us/lametro_staging pupa update lametro --import && \
+    $PUPADIR update lametro --scrape bills window=0 && \
+    $PUPADIR update lametro --import && \
+    SHARED_DB=True DATABASE_URL=postgis://datamade@lametro-upgrade.datamade.us/lametro_staging pupa update lametro --import)

--- a/scripts/lametro/full-scrape.sh
+++ b/scripts/lametro/full-scrape.sh
@@ -1,9 +1,17 @@
 #/bin/sh
+set -e
 
-(cd $APPDIR && \
-    $PUPADIR update lametro --scrape && \
-    $PUPADIR update lametro --import && \
-    SHARED_DB=True DATABASE_URL=postgis://datamade@lametro-upgrade.datamade.us/lametro_staging pupa update lametro --import && \
-    $PUPADIR update lametro --scrape bills window=0 && \
-    $PUPADIR update lametro --import && \
-    SHARED_DB=True DATABASE_URL=postgis://datamade@lametro-upgrade.datamade.us/lametro_staging pupa update lametro --import)
+exec 2>&1
+
+cd $APPDIR
+
+# Bills are windowed to 3 days by default. Scrape all people, all events, and
+# windowed bills.
+$PUPADIR update lametro --scrape
+$PUPADIR update lametro --import
+SHARED_DB=True DATABASE_URL=postgis://datamade@lametro-upgrade.datamade.us/lametro_staging pupa update lametro --import
+
+# Scrape all bills.
+$PUPADIR update lametro --scrape bills window=0
+$PUPADIR update lametro --import
+SHARED_DB=True DATABASE_URL=postgis://datamade@lametro-upgrade.datamade.us/lametro_staging pupa update lametro --import

--- a/scripts/lametro/windowed-bill-scrape.sh
+++ b/scripts/lametro/windowed-bill-scrape.sh
@@ -1,0 +1,6 @@
+#/bin/sh
+
+(cd $APPDIR && \
+    $PUPADIR update --datadir=/cache/bills/_data/ lametro bills window=$WINDOW && \
+    $PUPADIR update --datadir=/cache/bills/_data/ lametro --import && \
+    SHARED_DB=True DATABASE_URL=postgis://datamade@lametro-upgrade.datamade.us/lametro_staging pupa update --datadir=/cache/bills/_data/ lametro --import)

--- a/scripts/lametro/windowed-bill-scrape.sh
+++ b/scripts/lametro/windowed-bill-scrape.sh
@@ -4,6 +4,6 @@ set -e
 exec 2>&1
 
 cd $APPDIR
-$PUPADIR update --datadir=/cache/bills/_data/ lametro bills window=$WINDOW
+$PUPADIR update --datadir=/cache/bills/_data/ lametro --scrape bills window=$WINDOW
 $PUPADIR update --datadir=/cache/bills/_data/ lametro --import
 SHARED_DB=True DATABASE_URL=postgis://datamade@lametro-upgrade.datamade.us/lametro_staging pupa update --datadir=/cache/bills/_data/ lametro --import

--- a/scripts/lametro/windowed-bill-scrape.sh
+++ b/scripts/lametro/windowed-bill-scrape.sh
@@ -1,6 +1,9 @@
 #/bin/sh
+set -e
 
-(cd $APPDIR && \
-    $PUPADIR update --datadir=/cache/bills/_data/ lametro bills window=$WINDOW && \
-    $PUPADIR update --datadir=/cache/bills/_data/ lametro --import && \
-    SHARED_DB=True DATABASE_URL=postgis://datamade@lametro-upgrade.datamade.us/lametro_staging pupa update --datadir=/cache/bills/_data/ lametro --import)
+exec 2>&1
+
+cd $APPDIR
+$PUPADIR update --datadir=/cache/bills/_data/ lametro bills window=$WINDOW
+$PUPADIR update --datadir=/cache/bills/_data/ lametro --import
+SHARED_DB=True DATABASE_URL=postgis://datamade@lametro-upgrade.datamade.us/lametro_staging pupa update --datadir=/cache/bills/_data/ lametro --import

--- a/scripts/lametro/windowed-event-scrape.sh
+++ b/scripts/lametro/windowed-event-scrape.sh
@@ -1,0 +1,6 @@
+#/bin/sh
+
+(cd $APPDIR && \
+    $PUPADIR update --datadir=/cache/events/_data/ lametro --scrape events window=$WINDOW && \
+    $PUPADIR update --datadir=/cache/events/_data/ lametro --import && \
+    SHARED_DB=True DATABASE_URL=postgis://datamade@lametro-upgrade.datamade.us/lametro_staging pupa update --datadir=/cache/events/_data/ lametro --import)

--- a/scripts/lametro/windowed-event-scrape.sh
+++ b/scripts/lametro/windowed-event-scrape.sh
@@ -1,6 +1,9 @@
 #/bin/sh
+set -e
 
-(cd $APPDIR && \
-    $PUPADIR update --datadir=/cache/events/_data/ lametro --scrape events window=$WINDOW && \
-    $PUPADIR update --datadir=/cache/events/_data/ lametro --import && \
-    SHARED_DB=True DATABASE_URL=postgis://datamade@lametro-upgrade.datamade.us/lametro_staging pupa update --datadir=/cache/events/_data/ lametro --import)
+exec 2>&1
+
+cd $APPDIR
+$PUPADIR update --datadir=/cache/events/_data/ lametro --scrape events window=$WINDOW
+$PUPADIR update --datadir=/cache/events/_data/ lametro --import
+SHARED_DB=True DATABASE_URL=postgis://datamade@lametro-upgrade.datamade.us/lametro_staging pupa update --datadir=/cache/events/_data/ lametro --import

--- a/scripts/scrapers-us-municipal-crontask
+++ b/scripts/scrapers-us-municipal-crontask
@@ -18,33 +18,32 @@ PUPADIR=/home/datamade/.virtualenvs/opencivicdata/bin/pupa
 
 # Metro: Nightly
 # Full scrapes
-5 0 * * * datamade /usr/bin/flock /tmp/metrobills.lock /usr/bin/flock /tmp/metroevents.lock -c 'cd $APPDIR && $PUPADIR update lametro >> /tmp/lametro.log 2>&1 && $PUPADIR update lametro bills window=0 >> /tmp/lametro.log 2>&1'
+5 0 * * * datamade /usr/bin/flock /tmp/metrobills.lock /usr/bin/flock /tmp/metroevents.lock $APPDIR/scripts/metro/full-scrape.sh >> /tmp/lametro.log 2>&1
 
 # Metro: Sunday to Thursday
 # Windowed scrapes
-0,15,30,45 * * * 0-4 datamade /usr/bin/flock -n /tmp/metroevents.lock -c 'cd $APPDIR && $PUPADIR update --datadir=/cache/events/_data/ lametro events window=0.05 >> /tmp/lametro.log 2>&1'
-5,20,35,50 * * * 0-4 datamade /usr/bin/flock -n /tmp/metrobills.lock -c 'cd $APPDIR && $PUPADIR update --datadir=/cache/bills/_data/ lametro bills window=0.05 >> /tmp/lametro.log 2>&1'
+0,15,30,45 * * * 0-4 datamade /usr/bin/flock -n /tmp/metroevents.lock -c "WINDOW=0.05 $APPDIR/scripts/metro/windowed-event-scrape.sh" >> /tmp/lametro.log 2>&1
+5,20,35,50 * * * 0-4 datamade /usr/bin/flock -n /tmp/metrobills.lock -c "WINDOW=0.05 $APPDIR/scripts/metro/windowed-bill-scrape.sh" >> /tmp/lametro.log 2>&1
 
 # Metro: Friday, midnight to 8:50 pm UTC
 # Windowed scrapes
-0,15,30,45 0-20 * * 5 datamade /usr/bin/flock -n /tmp/metroevents.lock -c 'cd $APPDIR && $PUPADIR update --datadir=/cache/events/_data/ lametro events window=0.05 >> /tmp/lametro.log 2>&1'
-5,20,35,50 0-20 * * 5 datamade /usr/bin/flock -n /tmp/metrobills.lock -c 'cd $APPDIR && $PUPADIR update --datadir=/cache/bills/_data/ lametro bills window=0.05 >> /tmp/lametro.log 2>&1'
+0,15,30,45 0-20 * * 5 datamade /usr/bin/flock -n /tmp/metroevents.lock -c "WINDOW=0.05 $APPDIR/scripts/metro/windowed-event-scrape.sh" >> /tmp/lametro.log 2>&1
+5,20,35,50 0-20 * * 5 datamade /usr/bin/flock -n /tmp/metrobills.lock -c "WINDOW=0.05 $APPDIR/scripts/metro/windowed-bill-scrape.sh" >> /tmp/lametro.log 2>&1
 
 # Metro: Friday, 9:00 pm UTC to Saturday, 5:50 am UTC
 # Full scrapes
-0 21-23 * * 5 datamade /usr/bin/flock -n /tmp/metroevents.lock -c 'cd $APPDIR && $PUPADIR update --datadir=/cache/events/_data/ lametro events --rpm=0 >> /tmp/lametro.log 2>&1'
-5 21-23 * * 5 datamade /usr/bin/flock -n /tmp/metrobills.lock -c 'cd $APPDIR && $PUPADIR update --datadir=/cache/bills/_data/ lametro bills window=0 --rpm=0 >> /tmp/lametro.log 2>&1'
-0 0-5 * * 6 datamade /usr/bin/flock -n /tmp/metroevents.lock -c 'cd $APPDIR && $PUPADIR update --datadir=/cache/events/_data/ lametro events --rpm=0 >> /tmp/lametro.log 2>&1'
-5 0-5 * * 6 datamade /usr/bin/flock -n /tmp/metrobills.lock -c 'cd $APPDIR && $PUPADIR update --datadir=/cache/bills/_data/ lametro bills window=0 --rpm=0 >> /tmp/lametro.log 2>&1'
+0 21-23 * * 5 datamade /usr/bin/flock -n /tmp/metroevents.lock -c $APPDIR/scripts/metro/fast-full-event-scrape.sh >> /tmp/lametro.log 2>&1
+5 21-23 * * 5 datamade /usr/bin/flock -n /tmp/metrobills.lock -c $APPDIR/scripts/metro/fast-full-bill-scrape.sh >> /tmp/lametro.log 2>&1
+0 0-5 * * 6 datamade /usr/bin/flock -n /tmp/metroevents.lock -c $APPDIR/scripts/metro/fast-full-event-scrape.sh >> /tmp/lametro.log 2>&1
+5 0-5 * * 6 datamade /usr/bin/flock -n /tmp/metrobills.lock -c $APPDIR/scripts/metro/fast-full-bill-scrape.sh >> /tmp/lametro.log 2>&1
 
 # Windowed scrapes
-30,45 21-23 * * 5 datamade /usr/bin/flock -n /tmp/metroevents.lock -c 'cd $APPDIR && $PUPADIR update --datadir=/cache/events/_data/ lametro events window=1 >> /tmp/lametro.log 2>&1'
-35,50 21-23 * * 5 datamade /usr/bin/flock -n /tmp/metrobills.lock -c 'cd $APPDIR && $PUPADIR update --datadir=/cache/bills/_data/ lametro bills window=1 >> /tmp/lametro.log 2>&1'
-30,45 0-5 * * 6 datamade /usr/bin/flock -n /tmp/metroevents.lock -c 'cd $APPDIR && $PUPADIR update --datadir=/cache/events/_data/ lametro events window=1 >> /tmp/lametro.log 2>&1'
-35,50 0-5 * * 6 datamade /usr/bin/flock -n /tmp/metrobills.lock -c 'cd $APPDIR && $PUPADIR update --datadir=/cache/bills/_data/ lametro bills window=1 >> /tmp/lametro.log 2>&1'
+30,45 21-23 * * 5 datamade /usr/bin/flock -n /tmp/metroevents.lock -c "WINDOW=1 $APPDIR/scripts/metro/windowed-event-scrape.sh" >> /tmp/lametro.log 2>&1
+35,50 21-23 * * 5 datamade /usr/bin/flock -n /tmp/metrobills.lock -c "WINDOW=1 $APPDIR/scripts/metro/windowed-bill-scrape.sh" >> /tmp/lametro.log 2>&1
+30,45 0-5 * * 6 datamade /usr/bin/flock -n /tmp/metroevents.lock -c "WINDOW=1 $APPDIR/scripts/metro/windowed-event-scrape.sh" >> /tmp/lametro.log 2>&1
+35,50 0-5 * * 6 datamade /usr/bin/flock -n /tmp/metrobills.lock -c "WINDOW=1 $APPDIR/scripts/metro/windowed-bill-scrape.sh" >> /tmp/lametro.log 2>&1
 
 # Metro: Saturday, 6:00 am UTC 11:50 pm UTC
 # Windowed scrapes
-0,15,30,45 6-23 * * 6 datamade /usr/bin/flock -n /tmp/metroevents.lock -c 'cd $APPDIR && $PUPADIR update --datadir=/cache/events/_data/ lametro events window=0.05 >> /tmp/lametro.log 2>&1'
-5,20,35,50 6-23 * * 6 datamade /usr/bin/flock -n /tmp/metrobills.lock -c 'cd $APPDIR && $PUPADIR update --datadir=/cache/bills/_data/ lametro bills window=0.05 >> /tmp/lametro.log 2>&1'
- 
+0,15,30,45 0-20 * * 5 datamade /usr/bin/flock -n /tmp/metroevents.lock -c "WINDOW=0.05 $APPDIR/scripts/metro/windowed-event-scrape.sh" >> /tmp/lametro.log 2>&1
+5,20,35,50 0-20 * * 5 datamade /usr/bin/flock -n /tmp/metrobills.lock -c "WINDOW=0.05 $APPDIR/scripts/metro/windowed-bill-scrape.sh" >> /tmp/lametro.log 2>&1'

--- a/scripts/scrapers-us-municipal-crontask
+++ b/scripts/scrapers-us-municipal-crontask
@@ -18,32 +18,32 @@ PUPADIR=/home/datamade/.virtualenvs/opencivicdata/bin/pupa
 
 # Metro: Nightly
 # Full scrapes
-5 0 * * * datamade /usr/bin/flock /tmp/metrobills.lock /usr/bin/flock /tmp/metroevents.lock $APPDIR/scripts/metro/full-scrape.sh >> /tmp/lametro.log 2>&1
+5 0 * * * datamade /usr/bin/flock /tmp/metrobills.lock /usr/bin/flock /tmp/metroevents.lock $APPDIR/scripts/metro/full-scrape.sh >> /tmp/lametro.log
 
 # Metro: Sunday to Thursday
 # Windowed scrapes
-0,15,30,45 * * * 0-4 datamade /usr/bin/flock -n /tmp/metroevents.lock -c "WINDOW=0.05 $APPDIR/scripts/metro/windowed-event-scrape.sh" >> /tmp/lametro.log 2>&1
-5,20,35,50 * * * 0-4 datamade /usr/bin/flock -n /tmp/metrobills.lock -c "WINDOW=0.05 $APPDIR/scripts/metro/windowed-bill-scrape.sh" >> /tmp/lametro.log 2>&1
+0,15,30,45 * * * 0-4 datamade /usr/bin/flock -n /tmp/metroevents.lock -c "WINDOW=0.05 $APPDIR/scripts/metro/windowed-event-scrape.sh" >> /tmp/lametro.log
+5,20,35,50 * * * 0-4 datamade /usr/bin/flock -n /tmp/metrobills.lock -c "WINDOW=0.05 $APPDIR/scripts/metro/windowed-bill-scrape.sh" >> /tmp/lametro.log
 
 # Metro: Friday, midnight to 8:50 pm UTC
 # Windowed scrapes
-0,15,30,45 0-20 * * 5 datamade /usr/bin/flock -n /tmp/metroevents.lock -c "WINDOW=0.05 $APPDIR/scripts/metro/windowed-event-scrape.sh" >> /tmp/lametro.log 2>&1
-5,20,35,50 0-20 * * 5 datamade /usr/bin/flock -n /tmp/metrobills.lock -c "WINDOW=0.05 $APPDIR/scripts/metro/windowed-bill-scrape.sh" >> /tmp/lametro.log 2>&1
+0,15,30,45 0-20 * * 5 datamade /usr/bin/flock -n /tmp/metroevents.lock -c "WINDOW=0.05 $APPDIR/scripts/metro/windowed-event-scrape.sh" >> /tmp/lametro.log
+5,20,35,50 0-20 * * 5 datamade /usr/bin/flock -n /tmp/metrobills.lock -c "WINDOW=0.05 $APPDIR/scripts/metro/windowed-bill-scrape.sh" >> /tmp/lametro.log
 
 # Metro: Friday, 9:00 pm UTC to Saturday, 5:50 am UTC
 # Full scrapes
-0 21-23 * * 5 datamade /usr/bin/flock -n /tmp/metroevents.lock -c $APPDIR/scripts/metro/fast-full-event-scrape.sh >> /tmp/lametro.log 2>&1
-5 21-23 * * 5 datamade /usr/bin/flock -n /tmp/metrobills.lock -c $APPDIR/scripts/metro/fast-full-bill-scrape.sh >> /tmp/lametro.log 2>&1
-0 0-5 * * 6 datamade /usr/bin/flock -n /tmp/metroevents.lock -c $APPDIR/scripts/metro/fast-full-event-scrape.sh >> /tmp/lametro.log 2>&1
-5 0-5 * * 6 datamade /usr/bin/flock -n /tmp/metrobills.lock -c $APPDIR/scripts/metro/fast-full-bill-scrape.sh >> /tmp/lametro.log 2>&1
+0 21-23 * * 5 datamade /usr/bin/flock -n /tmp/metroevents.lock -c $APPDIR/scripts/metro/fast-full-event-scrape.sh >> /tmp/lametro.log
+5 21-23 * * 5 datamade /usr/bin/flock -n /tmp/metrobills.lock -c $APPDIR/scripts/metro/fast-full-bill-scrape.sh >> /tmp/lametro.log
+0 0-5 * * 6 datamade /usr/bin/flock -n /tmp/metroevents.lock -c $APPDIR/scripts/metro/fast-full-event-scrape.sh >> /tmp/lametro.log
+5 0-5 * * 6 datamade /usr/bin/flock -n /tmp/metrobills.lock -c $APPDIR/scripts/metro/fast-full-bill-scrape.sh >> /tmp/lametro.log
 
 # Windowed scrapes
-30,45 21-23 * * 5 datamade /usr/bin/flock -n /tmp/metroevents.lock -c "WINDOW=1 $APPDIR/scripts/metro/windowed-event-scrape.sh" >> /tmp/lametro.log 2>&1
-35,50 21-23 * * 5 datamade /usr/bin/flock -n /tmp/metrobills.lock -c "WINDOW=1 $APPDIR/scripts/metro/windowed-bill-scrape.sh" >> /tmp/lametro.log 2>&1
-30,45 0-5 * * 6 datamade /usr/bin/flock -n /tmp/metroevents.lock -c "WINDOW=1 $APPDIR/scripts/metro/windowed-event-scrape.sh" >> /tmp/lametro.log 2>&1
-35,50 0-5 * * 6 datamade /usr/bin/flock -n /tmp/metrobills.lock -c "WINDOW=1 $APPDIR/scripts/metro/windowed-bill-scrape.sh" >> /tmp/lametro.log 2>&1
+30,45 21-23 * * 5 datamade /usr/bin/flock -n /tmp/metroevents.lock -c "WINDOW=1 $APPDIR/scripts/metro/windowed-event-scrape.sh" >> /tmp/lametro.log
+35,50 21-23 * * 5 datamade /usr/bin/flock -n /tmp/metrobills.lock -c "WINDOW=1 $APPDIR/scripts/metro/windowed-bill-scrape.sh" >> /tmp/lametro.log
+30,45 0-5 * * 6 datamade /usr/bin/flock -n /tmp/metroevents.lock -c "WINDOW=1 $APPDIR/scripts/metro/windowed-event-scrape.sh" >> /tmp/lametro.log
+35,50 0-5 * * 6 datamade /usr/bin/flock -n /tmp/metrobills.lock -c "WINDOW=1 $APPDIR/scripts/metro/windowed-bill-scrape.sh" >> /tmp/lametro.log
 
 # Metro: Saturday, 6:00 am UTC 11:50 pm UTC
 # Windowed scrapes
-0,15,30,45 0-20 * * 5 datamade /usr/bin/flock -n /tmp/metroevents.lock -c "WINDOW=0.05 $APPDIR/scripts/metro/windowed-event-scrape.sh" >> /tmp/lametro.log 2>&1
-5,20,35,50 0-20 * * 5 datamade /usr/bin/flock -n /tmp/metrobills.lock -c "WINDOW=0.05 $APPDIR/scripts/metro/windowed-bill-scrape.sh" >> /tmp/lametro.log 2>&1'
+0,15,30,45 0-20 * * 5 datamade /usr/bin/flock -n /tmp/metroevents.lock -c "WINDOW=0.05 $APPDIR/scripts/metro/windowed-event-scrape.sh" >> /tmp/lametro.log
+5,20,35,50 0-20 * * 5 datamade /usr/bin/flock -n /tmp/metrobills.lock -c "WINDOW=0.05 $APPDIR/scripts/metro/windowed-bill-scrape.sh" >> /tmp/lametro.log


### PR DESCRIPTION
## Description

This PR updates the cron to populate the Metro upgrade database, as well as the OCD API, following the pattern set in https://github.com/datamade/scrapers-us-municipal/pull/39.

Since there are so many different Metro commands, and because each job will involve at least four commands once there is a staging and production database (one command to scrape, one command to update the OCD API, one command to update the staging database, and one command to update the production database), I've broken the Metro cron tasks into descriptively named shell scripts that are run by the cron jobs. This will hopefully make the crons easier to read and debug.

Given the particularities of cron, I could use feedback on whether this will work as I expect it to, namely:

- Variables set at the top of the cron, e.g., `APPDIR`, should be accessible in the scripts the cron runs
- Variables set before the script is run, e.g., `WINDOW`, should be accessible in the scripts the cron runs
- Cron can run the shell scripts from the app directory without any weird permissions or updates to the `PATH`