### PR TITLE
don't do full scrape on **saturday** utc

### DIFF
--- a/scripts/la-metro-crontask
+++ b/scripts/la-metro-crontask
@@ -10,7 +10,7 @@ PUPADIR=/home/datamade/.virtualenvs/opencivicdata/bin/pupa
 
 # Full scrape
 
-5 0 * * 0-4,6 datamade /usr/bin/flock /tmp/metrobills.lock /usr/bin/flock /tmp/metroevents.lock $APPDIR/scripts/lametro/full-scrape.sh >> /tmp/lametro.log
+5 0 * * 0-5 datamade /usr/bin/flock /tmp/metrobills.lock /usr/bin/flock /tmp/metroevents.lock $APPDIR/scripts/lametro/full-scrape.sh >> /tmp/lametro.log
 
 # --- SUNDAY THROUGH THURSDAY ---
 


### PR DESCRIPTION
In order to turn off the full scrape for Friday evening in LA, we have to turn off the *Saturday* UTC cron.