### PR TITLE
Remove LA Metro staging imports

### DIFF
--- a/scripts/lametro/full-scrape.sh
+++ b/scripts/lametro/full-scrape.sh
@@ -9,11 +9,9 @@ cd $APPDIR
 # windowed bills.
 $PUPADIR update lametro --scrape
 SHARED_DB=True DATABASE_URL=postgis://datamade@3.93.9.229/lametro $PUPADIR update lametro --import
-SHARED_DB=True DATABASE_URL=postgis://datamade@3.93.9.229/lametro_staging $PUPADIR update lametro --import
 $PUPADIR update lametro --import
 
 # Scrape all bills.
 $PUPADIR update lametro --scrape bills window=0
 SHARED_DB=True DATABASE_URL=postgis://datamade@3.93.9.229/lametro $PUPADIR update lametro --import
-SHARED_DB=True DATABASE_URL=postgis://datamade@3.93.9.229/lametro_staging $PUPADIR update lametro --import
 $PUPADIR update lametro --import

--- a/scripts/lametro/person-scrape.sh
+++ b/scripts/lametro/person-scrape.sh
@@ -6,5 +6,4 @@ exec 2>&1
 cd $APPDIR
 $PUPADIR update --datadir=/cache/people/_data/ lametro --scrape people
 SHARED_DB=True DATABASE_URL=postgis://datamade@3.93.9.229/lametro $PUPADIR update --datadir=/cache/people/_data/ lametro --import people
-SHARED_DB=True DATABASE_URL=postgis://datamade@3.93.9.229/lametro_staging $PUPADIR update --datadir=/cache/people/_data/ lametro --import people
 $PUPADIR update --datadir=/cache/people/_data/ lametro --import people

--- a/scripts/lametro/windowed-event-scrape.sh
+++ b/scripts/lametro/windowed-event-scrape.sh
@@ -6,5 +6,4 @@ exec 2>&1
 cd $APPDIR
 $PUPADIR update --datadir=/cache/events/_data/ lametro --scrape events window=$WINDOW
 SHARED_DB=True DATABASE_URL=postgis://datamade@3.93.9.229/lametro $PUPADIR update --datadir=/cache/events/_data/ lametro --import
-SHARED_DB=True DATABASE_URL=postgis://datamade@3.93.9.229/lametro_staging $PUPADIR update --datadir=/cache/events/_data/ lametro --import
 $PUPADIR update --datadir=/cache/events/_data/ lametro --import


### PR DESCRIPTION
## Overview

This PR removes the staging import from LA Metro scraping tasks.

Connects https://github.com/datamade/la-metro-councilmatic/pull/625, https://github.com/datamade/la-metro-dashboard/pull/24

## Testing instructions

- Confirm the diff makes sense
    - I can deploy this to staging if it'd be helpful for testing