### PR TITLE
don't do windowed scrape if window is '0'

### DIFF
--- a/lametro/events.py
+++ b/lametro/events.py
@@ -185,7 +185,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
         return english_events
 
     def scrape(self, window=None) :
-        if window:
+        if window and float(window):
             n_days_ago = datetime.datetime.utcnow() - datetime.timedelta(float(window))
         else:
             n_days_ago = None


### PR DESCRIPTION
if window is the string '0' don't do a windowed scrape.

This was leading our fast_full_scrapes to not be windowed scrapes. 

