### PR TITLE
Specify --upgrade in Dockerfile so Git requirements are updated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /app
 
 COPY ./requirements.txt /app/requirements.txt
 RUN pip install --upgrade pip && \
-    pip install --no-cache-dir -r requirements.txt
+    pip install --no-cache-dir -r requirements.txt --upgrade
 
 COPY . /app
 


### PR DESCRIPTION
## Description

When installing from a repository, specifically a branch, `pip` won't retrieve updates to VCS requirements "if a satisfactory version of the package is already installed". References: https://github.com/pypa/pip/issues/2837, https://pip.pypa.io/en/latest/reference/pip_install/#vcs-support. The effect is that the latest versions of the dependencies we install from branches are captured in the first but not subsequent image builds. This PR adds the `--upgrade` flag to dependency installation to rectify this.

### Notes

We haven't released `python-legistar-scraper` on PyPI, so we can't install from a version. I, for one, would like to avoid having to update scraper requirements with each change, i.e., would prefer not to pin to a particular commit.

On the other hand, some of our dependencies (lxml, sh, requests) are not pinned to a particular version. @fgregg As our package management expert, do you see risks to adding the `--upgrade` flag in this way? Perhaps I should run a second `pip` command specifically for the Legistar lib? Happy for your thoughts!