### PR TITLE
Migrate to GitHub container registry

### DIFF
--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -1,0 +1,29 @@
+name: Publish Docker image to GitHub Container Registry
+
+on:
+  push:
+    branches:
+      - master
+      - deploy
+
+jobs:
+  publish:
+    name: Publish Docker image to GitHub Container Registry
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create tag from branch
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/${{ github.repository }}
+      - name: Push to GitHub Container Registry
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ git push origin master:deploy
 ```
 
 Pushing to the `deploy` branch will deploy the code to the OCD server (for
-scrapes scheduled by cron) and create a Docker Hub build in the [`datamade/scrapers-us-municipal`
-repository](https://hub.docker.com/repository/docker/datamade/scrapers-us-municipal)
-(for scrapes scheduled by Airflow, which are run in containers).
+scrapes scheduled by cron) and create a GitHub Container Registry build tagged
+with the relevant branch name (for scrapes scheduled by Airflow, which are run
+in containers).
 
 ## Logging
 

--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ branch:
 git push origin master:deploy
 ```
 
-Pushing to the `deploy` branch will deploy the code to the OCD server (for
-scrapes scheduled by cron) and create a GitHub Container Registry build tagged
-with the relevant branch name (for scrapes scheduled by Airflow, which are run
-in containers).
+Pushing to the `master` and `deploy` branches will deploy the code to the OCD
+server (for scrapes scheduled by cron) and create a GitHub Container Registry
+build tagged with the relevant branch name (for scrapes scheduled by Airflow,
+which are run in containers).
 
 ## Logging
 


### PR DESCRIPTION
# Description

This PR adds a GitHub Action to publish tagged images to GHCR on pushes to `master` and `deploy`. These images will take the place of `staging` and `production` tagged images currently hosted in DockerHub, since automatic builds are no longer available for free accounts.

This is a twin PR to https://github.com/datamade/la-metro-councilmatic/pull/781. See [successful logs](https://github.com/datamade/la-metro-councilmatic/runs/4693633986) and [resultant tag](https://github.com/datamade/la-metro-councilmatic/pkgs/container/la-metro-councilmatic/12641378?tag=master).