### PR TITLE
logger class typo

### DIFF
--- a/chicago/bills.py
+++ b/chicago/bills.py
@@ -300,7 +300,7 @@ class ChicagoBillScraper(LegistarAPIBillScraper, Scraper):
                     relation_type = "replaces"
 
                 if relation_type is None:
-                    self.warn("Unclear relation for {0}".format(matter_id))
+                    self.warning("Unclear relation for {0}".format(matter_id))
 
                 else:
                     for relation in identified_relations:


### PR DESCRIPTION
I was trying to scrape the city council website because the api is no longer supported (https://github.com/datamade/chi-councilmatic/issues/202), and ran into this error which would crash the scraper process.